### PR TITLE
Add 3.10 support for installation and CI testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         # python-version: ["3.8", "3.9"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(name="Python-EasyGraph",
                      "License :: OSI Approved :: BSD License",
                      "Operating System :: OS Independent",
                  ],
-                 python_requires=">=3.6, <3.10",
+                 python_requires=">=3.6, <3.11",
                  install_requires=[
                      "numpy>=1.18.5, <=1.19.5; python_version=='3.6'",
                      "numpy>=1.18.5; python_version>='3.7'",


### PR DESCRIPTION
I installed the project on 3.10, setup.py works with minimal change.