### PR TITLE
Fix: make workflow for testing packages with pytest work again

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,28 +10,30 @@ jobs:
       fail-fast: false
       matrix:
         # ubuntu 22.04 has deprecated python 3.6
-        python-version: [ "3.8", "3.9", "3.10","3.11", "3.12", "3.13"]
+        python-version: [ "3.8", "3.9", "3.10","3.11", "3.12"]
     steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: 'Build and install easygraph'
-        # still investigating issues, use the dummy workflow for now
-        # uses: tddschn/install-easygraph@master
-        uses: tddschn/install-easygraph/dummy@master
+      - name: Installing dependencies
+        uses: py-actions/py-dependency-install@v4
         with:
-          # use current repo
-          repository: '${{ github.repository }}'
-          # use current branch
-          ref: '${{ github.ref }}'
-          install-pytorch: 'true'
-          install-lxml: 'true'
-          extra-modules-to-install: 'optuna torch_scatter torch_geometric'
+          path: "requirements.txt"
 
+      - name: Installing test dependencies
+        run: |
+          pip install pytest
 
-      - uses: actions/checkout@v3
+      - name: Build and install package
+        run: |
+          pip install .
+
       - name: Test with pytest
         run: |
-          pytest --disable-warnings
+          pytest --disable-warnings --ignore=cpp_easygraph

--- a/easygraph/classes/test_base_graph_class.py
+++ b/easygraph/classes/test_base_graph_class.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 
-import tests
+import easygraph as eg
 
 
 print(

--- a/easygraph/classes/tests/test_graph.py
+++ b/easygraph/classes/tests/test_graph.py
@@ -4,7 +4,6 @@ import time
 
 # sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),'..', '..')))
 import easygraph as eg  # Spend 4.9s on importing this damn big lib.
-import tests
 
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ nose>=1.3.7
 pybind11>=2.10.4
 pydsge
 torch >= 1.12.1
+requests


### PR DESCRIPTION
This PR makes GHA for testing packages with pytest work again

Originally, the GHA didn't clone the pybind11 submodule when building the package, resulting in build errors.

Due to requests not being supported for python=3.13, I opted to remove testing for that version.

Also fixes some tests importing unnecessary modules.