### PR TITLE
Fix Windows OpenMP wheel build

### DIFF
--- a/.github/workflows/wheel_publish.yml
+++ b/.github/workflows/wheel_publish.yml
@@ -45,7 +45,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.3
         with:
           output-dir: dist/
-          merge-multiple: true
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -73,5 +72,4 @@ jobs:
           with:
             password: ${{ secrets.PYPI_API_TOKEN }}
             skip-existing: true
-
 

--- a/cpp_easygraph/functions/community/louvain.cpp
+++ b/cpp_easygraph/functions/community/louvain.cpp
@@ -312,10 +312,10 @@ double modularity_optimization_parallel_simplified(const Graph_L& G, vector<int>
                 }
 
                 if (best_comm != old_comm) {
-                    #pragma omp atomic update
+                    #pragma omp atomic
                     comm_weights[old_comm] -= weight_all;
 
-                    #pragma omp atomic update
+                    #pragma omp atomic
                     comm_weights[best_comm] += weight_all;
 
                     membership[u - 1] = best_comm;

--- a/cpp_easygraph/functions/community/modularity.cpp
+++ b/cpp_easygraph/functions/community/modularity.cpp
@@ -2,6 +2,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
+#include <cstddef>
 #ifdef _OPENMP
 #include <omp.h>
 #else
@@ -18,8 +19,10 @@ void addVectorsInPlace(std::vector<double>& v1, std::vector<double>& v2) {
         throw std::invalid_argument("Vectors must have the same size for element-wise addition.");
     }
 
+    const std::ptrdiff_t n = static_cast<std::ptrdiff_t>(v1.size());
+
     #pragma omp parallel for
-    for (size_t i = 0; i < v1.size(); ++i) {
+    for (std::ptrdiff_t i = 0; i < n; ++i) {
         double sum = v1[i] + v2[i];
         v1[i] = sum;
         v2[i] = sum;
@@ -32,8 +35,10 @@ double dotProduct(const std::vector<double>& v1, const std::vector<double>& v2) 
     }
     
     double result = 0.0;
+    const std::ptrdiff_t n = static_cast<std::ptrdiff_t>(v1.size());
+
     #pragma omp parallel for reduction(+:result)
-    for (size_t i = 0; i < v1.size(); ++i) {
+    for (std::ptrdiff_t i = 0; i < n; ++i) {
         result += v1[i] * v2[i];
     }
     return result;


### PR DESCRIPTION
## Summary
- replace MSVC-incompatible `#pragma omp atomic update` with the portable OpenMP atomic form
- use signed loop indices for OpenMP `parallel for` loops in modularity helpers
- remove the unsupported `merge-multiple` input from the cibuildwheel step

## Verification
- `python3 -m pip wheel . --no-deps -w /tmp/easygraph-wheel-openmp-fix`
- `git diff --check`

## Notes
The original failing workflow was `Build,download and publish wheels` run 27082170598. The hard failure was in the Windows `cp38-win32` wheel build with MSVC OpenMP errors C7660 and C3016. I did not manually rerun the publish workflow because it includes a PyPI publish job after wheel builds complete.
