### PR TITLE
Refine CI install and test checks

### DIFF
--- a/.github/workflows/pr_code_check.yaml
+++ b/.github/workflows/pr_code_check.yaml
@@ -3,9 +3,11 @@ name: PR code review
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - pybind11
   push:
     branches:
-      - master
+      - pybind11
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,6 +46,5 @@ jobs:
     - name: Build and install
       run: pip install --verbose .
 
-    - name: Test
-      run: python tests/test.py
-
+    - name: Smoke test
+      run: python -c "import os, tempfile; os.chdir(tempfile.gettempdir()); import easygraph as eg; G = eg.Graph(); G.add_edge(1, 2); assert G.number_of_nodes() == 2; assert G.number_of_edges() == 1"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,17 +1,38 @@
 name: pre-commit
 
 on:
+  workflow_dispatch:
   pull_request:
+    branches:
+      - pybind11
   push:
+    branches:
+      - pybind11
 
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - uses: pre-commit/action@v3.0.0
-      with:
-        extra_args: "--all-files"
+
+    - name: Install pre-commit
+      run: python -m pip install pre-commit
+
+    - name: Run pre-commit on changed files
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          base_ref="${{ github.event.pull_request.base.sha }}"
+        elif [[ -n "${{ github.event.before }}" && ! "${{ github.event.before }}" =~ ^0+$ ]]; then
+          base_ref="${{ github.event.before }}"
+        else
+          base_ref="$(git rev-parse HEAD~1)"
+        fi
+
+        pre-commit run --show-diff-on-failure --color=always --from-ref "$base_ref" --to-ref "${{ github.sha }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,13 @@
 name: Test the package with pytest
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - pybind11
+  push:
+    branches:
+      - pybind11
 
 jobs:
   pytest:
@@ -12,12 +19,12 @@ jobs:
         # ubuntu 22.04 has deprecated python 3.6
         python-version: [ "3.8", "3.9", "3.10","3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,4 +43,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --disable-warnings --ignore=cpp_easygraph
+          pytest easygraph --disable-warnings

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ class CMakeBuild(build_ext):
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DPython_EXECUTABLE={sys.executable}",
+            f"-DPython3_EXECUTABLE={sys.executable}",
+            "-DPYBIND11_FINDPYTHON=ON",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
             f"-DEASYGRAPH_ENABLE_GPU={'ON' if enable_gpu else 'OFF'}",
         ]


### PR DESCRIPTION
## Summary
- run the existing EasyGraph pytest suite only for pull requests and pushes targeting pybind11
- make the cross-platform PR code review job validate pip install plus a minimal EasyGraph graph smoke test
- replace the broken python tests/test.py command, since tests/test.py does not exist
- make the CMake/pybind11 build use the active Python interpreter so pip install produces a usable cpp_easygraph extension for that Python version
- run pre-commit only on changed files in CI, so historical formatting debt no longer blocks unrelated PRs
- update checkout/setup-python actions in the affected workflows

## Test layout notes
- The main EasyGraph pytest suite currently has 87 Python test files under easygraph.
- pytest.ini collects **/tests/test_*.py, so the C++ community cpp_*_test.py files are not part of the main pytest run.
- The cpp_easygraph/pybind11/tests tree belongs to the pybind11 submodule and should not be mixed into EasyGraph's normal CI.

## Verification
- YAML parsed successfully for .github/workflows/test.yaml, .github/workflows/pr_code_check.yaml, and .github/workflows/pre-commit.yaml
- git diff --check
- clean worktree with submodules: pip install requirements, pip install EasyGraph, then import EasyGraph from /tmp and build a minimal graph
- verified the installed extension uses the active Python ABI tag: cpp_easygraph.cpython-39-darwin.so in the local Python 3.9 venv

## Follow-up
This PR fixes CI structure, the broken cross-platform test command, the pre-commit all-files blocker, and a pip install/import packaging issue exposed by the new smoke test. The full pytest workflow can only turn green after the current baseline pytest failures are resolved.
