### PR TITLE
Fix pytest baseline geometry, NOBE, and NumPy issues

### DIFF
--- a/easygraph/functions/drawing/geometry.py
+++ b/easygraph/functions/drawing/geometry.py
@@ -24,9 +24,15 @@ def vlen(vector):
 
 
 def common_tangent_radian(r1, r2, d):
+    if r1 < 0 or r2 < 0:
+        raise ValueError("Circle radii must be non-negative.")
+    if d <= 0 or d < abs(r2 - r1):
+        raise ValueError("No common tangent exists for the given circles.")
     value = abs(r2 - r1) / d
-    if value > 1.0: value = 1.0
-    elif value < -1.0: value = -1.0
+    if value > 1.0:
+        value = 1.0
+    elif value < -1.0:
+        value = -1.0
     alpha = math.acos(value)
     alpha = alpha if r1 > r2 else pi - alpha
     return alpha

--- a/easygraph/functions/structural_holes/NOBE.py
+++ b/easygraph/functions/structural_holes/NOBE.py
@@ -40,6 +40,8 @@ def NOBE_SH(G, K, topk):
         raise ValueError("Embedding dimension K must be a positive integer.")
     if topk <= 0:
         raise ValueError("Parameter topk must be a positive integer.")
+    if G.number_of_nodes() == 0:
+        raise ValueError("NOBE_SH is not defined for an empty graph.")
     from sklearn.cluster import KMeans
 
     Y = eg.graph_embedding.NOBE(G, K)
@@ -109,6 +111,8 @@ def NOBE_GA_SH(G, K, topk):
         raise ValueError("Embedding dimension K must be a positive integer.")
     if topk <= 0:
         raise ValueError("Parameter topk must be a positive integer.")
+    if G.number_of_nodes() == 0:
+        raise ValueError("NOBE_GA_SH is not defined for an empty graph.")
     from sklearn.cluster import KMeans
 
     Y = eg.NOBE_GA(G, K)

--- a/easygraph/readwrite/gexf.py
+++ b/easygraph/readwrite/gexf.py
@@ -182,12 +182,13 @@ class GEXF:
         except ImportError:
             pass
         else:
+            np_float = getattr(np, "float_", np.float64)
             # prepend so that python types are created upon read (last entry wins)
             types = [
                 (np.float64, "float"),
                 (np.float32, "float"),
                 (np.float16, "float"),
-                (np.float_, "float"),
+                (np_float, "float"),
                 (np.int_, "int"),
                 (np.int8, "int"),
                 (np.int16, "int"),

--- a/easygraph/readwrite/graphml.py
+++ b/easygraph/readwrite/graphml.py
@@ -410,15 +410,16 @@ class GraphML:
         # These additions to types allow writing numpy types
         try:
             import numpy as np
-        except:
+        except ImportError:
             pass
         else:
+            np_float = getattr(np, "float_", np.float64)
             # prepend so that python types are created upon read (last entry wins)
             types = [
                 (np.float64, "float"),
                 (np.float32, "float"),
                 (np.float16, "float"),
-                (np.float_, "float"),
+                (np_float, "float"),
                 (np.int_, "int"),
                 (np.int8, "int"),
                 (np.int16, "int"),

--- a/easygraph/readwrite/tests/test_graphml.py
+++ b/easygraph/readwrite/tests/test_graphml.py
@@ -1283,7 +1283,8 @@ class TestWriteGraphML(BaseGraphML):
 
     def test_numpy_float(self):
         np = pytest.importorskip("numpy")
-        wt = np.float_(3.4)
+        np_float = getattr(np, "float_", np.float64)
+        wt = np_float(3.4)
         G = eg.Graph([(1, 2, {"weight": wt})])
         fd, fname = tempfile.mkstemp()
         self.writer(G, fname)


### PR DESCRIPTION
## Summary
- make `common_tangent_radian` raise `ValueError` for invalid circle geometry instead of silently clamping impossible inputs
- make `NOBE_SH` and `NOBE_GA_SH` reject empty graphs before indexing empty embedding results
- make GraphML/GEXF NumPy type mapping compatible with NumPy 2.x, where `np.float_` has been removed
- update the GraphML NumPy float test to use the same compatibility pattern

## Semantics
- The geometry change only rejects cases where the distance is non-positive or too small for the requested tangent calculation, plus negative radii.
- The NOBE change keeps the existing invalid `K` and `topk` behavior and adds an explicit empty-graph error.
- The NumPy change keeps `np.float64`, `np.float32`, and `np.float16` mappings unchanged, and falls back to `np.float64` when `np.float_` does not exist.

## Verification
- `git diff --check`
- `black --check` and `isort --check-only` on changed files
- focused pytest for geometry, NOBE, GEXF, and GraphML: `62 passed, 20 skipped` without lxml
- after installing lxml, GEXF/GraphML tests: `56 passed`
- manual checks for:
  - valid and invalid `common_tangent_radian` inputs
  - empty graph errors for `NOBE_SH` and `NOBE_GA_SH`
  - karate graph NOBE smoke checks
  - GraphML/GEXF writing with `np.float64` on NumPy 2.0

## Note
A local full `pytest easygraph` run was started but did not complete in a reasonable time on my machine, so I terminated it and relied on focused tests plus GitHub Actions for full-suite validation.
