### PR TITLE
Fix flaky local assortativity test

### DIFF
--- a/easygraph/functions/basic/tests/test_localassort.py
+++ b/easygraph/functions/basic/tests/test_localassort.py
@@ -1,4 +1,3 @@
-import random
 import sys
 
 import easygraph as eg
@@ -12,17 +11,12 @@ class TestLocalAssort:
     @classmethod
     def setup_class(self):
         self.G = eg.get_graph_karateclub()
-        random_value = [0, 1, 2, 3, 4, 5]
         edgelist = []
-        valuelist = []
         node_num = len(self.G.nodes)
         for e in self.G.edges:
             edgelist.append([e[0] - 1, e[1] - 1])
-        for i in range(0, node_num):
-            valuelist.append(random.choice(random_value))
         self.edgelist = np.int32(edgelist)
-        valuelist = np.int32(valuelist)
-        self.valuelist = valuelist
+        self.valuelist = np.arange(node_num, dtype=np.int32) % 6
 
     @pytest.mark.skipif(
         sys.version_info.major <= 3 and sys.version_info.minor <= 7,


### PR DESCRIPTION
## Summary

This PR removes the random node attributes from `TestLocalAssort.test_karateclub` and replaces them with deterministic, contiguous labels.

The previous test used:

```python
random.choice([0, 1, 2, 3, 4, 5])
```

without setting a random seed. This could randomly produce a non-contiguous label set such as `[0, 1, 2, 3, 5]`. `localAssort` assumes node attribute indices are contiguous and start from 0, which is also documented in the function docstring. When the generated labels skipped a category but still included label `5`, the sparse indicator matrix was created with too few columns and SciPy raised:

```text
ValueError: axis 1 index 5 exceeds matrix dimension 5
```

## Root Cause

The failing GitHub Actions run on Python 3.12 was caused by test randomness, not by the HIF fix and not by a Python 3.12-specific implementation regression. The 3.12 job happened to sample a bad non-contiguous label set; other matrix jobs sampled valid data and passed.

## Changes

- Remove the unused `random` import.
- Replace random karateclub labels with deterministic labels:

```python
np.arange(node_num, dtype=np.int32) % 6
```

This keeps six categories in the test while guaranteeing labels are contiguous from 0 to 5.

## Validation

Local pytest was intentionally not run per maintainer request. GitHub Actions will validate the full pytest matrix automatically for this PR and again on merge to `pybind11`.

Lightweight local check run:

- `git diff --check`